### PR TITLE
Fix subgraph crash when indexing

### DIFF
--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -31,24 +31,6 @@ function supportsInterface(
   return !supports.reverted && supports.value == expected;
 }
 
-function setCharAt(str: string, index: i32, char: string): string {
-  if (index > str.length - 1) return str;
-  return str.substr(0, index) + char + str.substr(index + 1);
-}
-
-function normalize(strValue: string): string {
-  if (strValue.length === 1 && strValue.charCodeAt(0) === 0) {
-    return '';
-  } else {
-    for (let i = 0; i < strValue.length; i++) {
-      if (strValue.charCodeAt(i) === 0) {
-        strValue = setCharAt(strValue, i, '\ufffd'); // graph-node db does not support string with '\u0000'
-      }
-    }
-    return strValue;
-  }
-}
-
 export function handleTransfer(event: Transfer): void {
   let tokenId = event.params.id;
   let id = event.address.toHex() + '_' + tokenId.toString();
@@ -93,11 +75,11 @@ export function handleTransfer(event: Transfer): void {
       tokenContract.numOwners = ZERO;
       let name = contract.try_name();
       if (!name.reverted) {
-        tokenContract.name = normalize(name.value);
+        tokenContract.name = name.value;
       }
       let symbol = contract.try_symbol();
       if (!symbol.reverted) {
-        tokenContract.symbol = normalize(symbol.value);
+        tokenContract.symbol = symbol.value;
       }
     } else {
       return;
@@ -159,7 +141,7 @@ export function handleTransfer(event: Transfer): void {
         if (tokenContract.supportsEIP721Metadata) {
           let metadataURI = contract.try_tokenURI(tokenId);
           if (!metadataURI.reverted) {
-            eip721Token.tokenURI = normalize(metadataURI.value);
+            eip721Token.tokenURI = metadataURI.value;
           } else {
             eip721Token.tokenURI = '';
           }


### PR DESCRIPTION
# Description
The normalize function is used for handling string with null character for graphnode database because in the past graphnode did not support handle string null, but in latest version graphnode supported it, so i think we do not need the normalize function anymore. For more information, please check in graphnode [issue](https://github.com/graphprotocol/graph-node/issues/1597) and graphnode [PR](https://github.com/graphprotocol/graph-node/pull/1656)

Fixes #4
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Evidence**:
Subgraph succeeded indexing the NFT have id 0x3cbeef2455176b9b93f0830d05d08386753316f4_1 (transaction hash: b84b76b1d53fdd3aac091f844da42f2f88a38d35fe9d27baa5bb3a9895fba06d) which have symbol field is very long string with many null character

<img width="1264" height="264" alt="Screenshot 2025-09-10 at 09 09 26" src="https://github.com/user-attachments/assets/8f2d91ee-a16a-4b1c-a700-8f084fca1f62" />


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules