### PR TITLE
Update remove get tokenUri eip721

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ NETWORK_NAME=gusandbox START_BLOCK=1 SUBGRAPH_NAME=gu-corp/eip721 GRAPH_NODE_URL
     contract
     tokenID
     owner
-    tokenURI
   }
 }
 ```
@@ -38,7 +37,6 @@ or
     contract
     tokenID
     owner
-    tokenURI
     mintTime
   }
   

--- a/schema.graphql
+++ b/schema.graphql
@@ -11,7 +11,6 @@ type Token @entity {
   tokenID: BigInt!
   owner: Owner!
   mintTime: BigInt!
-  tokenURI: String!
 }
 
 type TokenContract @entity {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -138,25 +138,6 @@ export function handleTransfer(event: Transfer): void {
         eip721Token.contract = tokenContract.id;
         eip721Token.tokenID = tokenId;
         eip721Token.mintTime = event.block.timestamp;
-        if (tokenContract.supportsEIP721Metadata) {
-          let metadataURI = contract.try_tokenURI(tokenId);
-          if (!metadataURI.reverted) {
-            // Limit tokenURI length to prevent RPC errors with large responses
-            // Some tokens return data exceeding RPC provider limits (>1MB)
-            let uri = metadataURI.value;
-            if (uri.length > 10000) {
-              // Truncate excessively long URIs and add indicator
-              eip721Token.tokenURI = uri.substring(0, 10000) + '...[truncated]';
-            } else {
-              eip721Token.tokenURI = uri;
-            }
-          } else {
-            eip721Token.tokenURI = '';
-          }
-        } else {
-          // log.error('tokenURI not supported {}', [tokenContract.id]);
-          eip721Token.tokenURI = ''; // TODO null ?
-        }
       }
 
       if (from == ZERO_ADDRESS_STRING) {


### PR DESCRIPTION
# Description
Update remove get tokenUri eip721, fix crash when tokenURI of NFT is too large

Fixes # (issue)

## Type of change

(Please delete options that are not relevant.)

- [x] Bug fix (non-breaking change which fixes an issue)

**Evidence**:

<img width="1501" height="679" alt="Screenshot 2026-01-05 at 16 25 17" src="https://github.com/user-attachments/assets/23e6898e-1c4f-4e54-a542-8a444fad87ce" />


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
