### PR TITLE
Fix(react): prevent base64 images from disappearing after gateway timeout

### DIFF
--- a/packages/react/src/components/TokenMedia/TokenMedia.tsx
+++ b/packages/react/src/components/TokenMedia/TokenMedia.tsx
@@ -131,6 +131,7 @@ function useResolvedSrc(options: {
 
   useEffect(() => {
     if (!src || loadedRef.current || exhausted) return;
+    if (src.startsWith('data:')) return;
 
     const timer = setTimeout(() => {
       if (!loadedRef.current) {


### PR DESCRIPTION
# Description

Fix: prevent base64 (data URI) images from disappearing after gateway timeout

In the `useResolvedSrc` hook, a `useEffect` resets `loadedRef.current = false` and starts a gateway timeout. For data URIs (`data:image/...;base64,...`), the browser decodes the image synchronously, so `<img onLoad>` fires **before** `useEffect` runs. This causes the effect to overwrite `loadedRef = true` back to `false`, and the timeout then incorrectly triggers gateway fallback — eventually removing the image.

```
onLoad → loadedRef = true → useEffect → loadedRef = false (overwrite) → timeout → onError → image gone
```

HTTP URLs are unaffected because `onLoad` fires after the effect (due to network latency).

### Fix

Skip the gateway timeout for `data:` URIs since they don't involve network requests:

```ts
if (src.startsWith('data:')) return;
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
